### PR TITLE
Scanning improvements

### DIFF
--- a/grinding_rviz_plugin/src/scanning_widget.h
+++ b/grinding_rviz_plugin/src/scanning_widget.h
@@ -117,6 +117,7 @@ protected:
   //YAML part in order to parse calibration sls2 matrix value
   QLabel *calibration_yaml_label_;
   QLineEdit *calibration_yaml_file_;
+  QDoubleSpinBox* down_sampling_leaf_size_;
   QPushButton *calibration_yaml_browse_button_;
 
   //Widget for point cloud

--- a/scanning/src/scanning.cpp
+++ b/scanning/src/scanning.cpp
@@ -110,7 +110,7 @@ bool moveRobotScan(scanning::ScanningService::Request &req, scanning::ScanningSe
   catch(const YAML::Exception &e)
   {
     res.ReturnStatus = false;
-    res.ReturnMessage = "Problem occured during parsing yaml file for joint values, problem is: " + e.msg;
+    res.ReturnMessage = "Problem occurred during parsing yaml file for joint values, problem is: " + e.msg;
     return true;
   }
 
@@ -236,14 +236,10 @@ bool moveRobotScan(scanning::ScanningService::Request &req, scanning::ScanningSe
                     "/" + boost::lexical_cast<std::string>(joint_list.size()) + " captured";
       status_pub->publish(status);
 
-      // Resize point cloud in meters
-      Eigen::Affine3d resize_pc_meters(Eigen::Affine3d::Identity());
-      resize_pc_meters.matrix() *= 0.001;
-      pcl::transformPointCloud(*point_cloud, *point_cloud, resize_pc_meters);
-
-      // Transform point cloud in order to put it on robot frame
+      // Transform point cloud in order into the robot frame
       Eigen::Affine3d transformation_pc(Eigen::Affine3d::Identity());
       transformation_pc = matrix_transform * calibration * calib_sls_2;
+      transformation_pc *= 0.001; // Transform millimeters to meters
 
       pcl::transformPointCloud(*point_cloud, *point_cloud, transformation_pc);
 

--- a/scanning/src/scanning.cpp
+++ b/scanning/src/scanning.cpp
@@ -252,8 +252,7 @@ bool moveRobotScan(scanning::ScanningService::Request &req, scanning::ScanningSe
   status_pub->publish(status);
 
   pcl::VoxelGrid<PointXYZ> sor;
-  double leaf_size (0.003);
-  sor.setLeafSize (leaf_size, leaf_size, leaf_size);
+  sor.setLeafSize (req.VoxelGridLeafSize, req.VoxelGridLeafSize, req.VoxelGridLeafSize);
   sor.setInputCloud (stacked_point_cloud);
   sor.filter (*stacked_point_cloud);
 

--- a/scanning/srv/ScanningService.srv
+++ b/scanning/srv/ScanningService.srv
@@ -4,6 +4,7 @@ string CADName
 string MarkerName
 string SLS2ServerName
 string SLS2IpAddress
+float64 VoxelGridLeafSize
 ---
 bool ReturnStatus
 string ReturnMessage


### PR DESCRIPTION
- Don't transform the point cloud twice, transform only one time to save time.
- User can now specify the voxel grid leaf size in the GUI when scanning.