### PR TITLE
Improve service calls

### DIFF
--- a/rviz_plugin/src/comparison_widget.cpp
+++ b/rviz_plugin/src/comparison_widget.cpp
@@ -86,10 +86,15 @@ void fanuc_grinding_rviz_plugin::ComparisonWidget::Comparison()
 
   // Call client service
   comparison_service_.call(srv_comparison_);
-  // Display return message in Qt panel
   Q_EMIT sendStatus(QString::fromStdString(srv_comparison_.response.ReturnMessage));
 
-  Q_EMIT enablePanelPathPlanning();
+  if(srv_comparison_.response.ReturnStatus == true)
+    Q_EMIT enablePanelPathPlanning();
+  else
+  {
+    Q_EMIT sendMsgBox("Error comparing meshes",
+                      QString::fromStdString(srv_comparison_.response.ReturnMessage), "");
+  }
 
   // Re-enable UI
   Q_EMIT enablePanel(true); // Enable UI

--- a/rviz_plugin/src/path_planning_widget.h
+++ b/rviz_plugin/src/path_planning_widget.h
@@ -51,18 +51,16 @@ Q_SIGNALS:
   void getCADAndScanParams();
 
 public Q_SLOTS:
-  virtual void ComputeTrajectory();
-  virtual void VisualizeTrajectory();
-  virtual void SimulateTrajectory();
+  virtual void pathPlanningService();
   void newStatusMessage(const std_msgs::String::ConstPtr& msg);
 
 protected Q_SLOTS:
   virtual void triggerSave();
   void updateGUI();
   void updateInternalValues();
-  void ComputeTrajectoryButtonHandler();
-  void VisualizeTrajectoryButtonHandler();
-  void SimulateTrajectoryButtonHandler();
+  void computeTrajectoryButtonHandler();
+  void visualizeTrajectoryButtonHandler();
+  void executeTrajectoryButtonHandler();
   void enableComputeTrajectoryButtonHandler(bool);
   void enableVizSimButtonHandler();
   void generateTrajectoryButtonHandler();


### PR DESCRIPTION
- Check return status of the service calls
- Display message boxes when error
- In PathPlanningWidget, use only one service functions for all three buttons (compute, visualize, execute)

@KevinBollore please check that the buttons behavior is still ok.