### PR TITLE
Make service node/threads sleep to greatly reduce CPU usage

### DIFF
--- a/alignment/src/alignment.cpp
+++ b/alignment/src/alignment.cpp
@@ -41,6 +41,7 @@ int main(int argc, char **argv)
 
   while (node->ok())
   {
+    sleep(1);
   }
   spinner.stop();
   return 0;

--- a/comparison/src/comparison.cpp
+++ b/comparison/src/comparison.cpp
@@ -42,6 +42,7 @@ int main(int argc, char **argv)
 
   while (node->ok())
   {
+    sleep(1);
   }
   spinner.stop();
   return 0;

--- a/execute_joint_state/src/execute_joint_state.cpp
+++ b/execute_joint_state/src/execute_joint_state.cpp
@@ -64,11 +64,12 @@ int main(int argc, char **argv)
 
   // Create service server and wait for incoming requests
   ros::ServiceServer service = node->advertiseService("execute_joint_state_service", moveRobotExecuteJointState);
-  ros::AsyncSpinner spinner(2);
+  ros::AsyncSpinner spinner(1);
   spinner.start();
 
   while (node->ok())
   {
+    sleep(1);
   }
   spinner.stop();
   return 0;

--- a/path_planning/src/path_planning.cpp
+++ b/path_planning/src/path_planning.cpp
@@ -163,6 +163,7 @@ int main(int argc,
 
   while (node->ok())
   {
+    sleep(1);
   }
   spinner.stop();
   return 0;

--- a/post_processor/src/post_processor.cpp
+++ b/post_processor/src/post_processor.cpp
@@ -140,8 +140,8 @@ int main(int argc, char **argv)
 
   while (node->ok())
   {
+    sleep(1);
   }
-
   spinner.stop();
   return 0;
 }

--- a/publish_meshfile/src/publish_meshfile.cpp
+++ b/publish_meshfile/src/publish_meshfile.cpp
@@ -115,6 +115,7 @@ int main(int argc, char **argv)
 
   while (node->ok())
   {
+    sleep(1);
   }
   spinner.stop();
   return 0;

--- a/scanning/src/scanning.cpp
+++ b/scanning/src/scanning.cpp
@@ -304,6 +304,7 @@ int main(int argc, char **argv)
 
   while (node->ok())
   {
+    sleep(1);
   }
   spinner.stop();
   return 0;


### PR DESCRIPTION
Fixes #96 

The threads were not told to sleep so the CPU round robin was trying to distribute time for each thread to run a `while` loop as fast as it can. This is very bad for performance and useless; this PR lets each of our service threads sleep 1 seconds to reduce CPU usage.